### PR TITLE
Unselect by enter

### DIFF
--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -326,7 +326,12 @@ define([
 
           evt.preventDefault();
         } else if (key === KEYS.ENTER) {
-          self.trigger('results:select', {});
+          
+          if (self.options.get('unselectByEnter')) {
+            self.trigger('results:toggle', {});
+          } else {
+            self.trigger('results:select', {});
+          }
 
           evt.preventDefault();
         } else if ((key === KEYS.SPACE && evt.ctrlKey)) {

--- a/src/js/select2/defaults.js
+++ b/src/js/select2/defaults.js
@@ -365,6 +365,7 @@ define([
       maximumSelectionLength: 0,
       minimumResultsForSearch: 0,
       selectOnClose: false,
+      unselectByEnter: false,
       sorter: function (data) {
         return data;
       },


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

Added configurable option "unselectByEnter"

- If set to TRUE it is possible to unselect options by pressing the Enter key
- If this is related to an existing ticket, include a link to it as well.
